### PR TITLE
Rename `ant LemminiFrame` to `ant run`, format & fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RetroLemmini
 
-A continuation of the Lemmini family of engines (Lemmini, SuperLemmini, RetroLemmini) which aims to fix a few bugs and generally update the engine.
+A continuation of the Lemmini family of engines (Lemmini, SuperLemmini, SuperLemminiToo) which aims to fix a few bugs and generally update the engine.
 
 ## Build Instructions
 
@@ -36,19 +36,19 @@ please visit [RetroLemmini's release topic on Lemmings Forums](https://www.lemmi
 ### From Will (RetroLemmini developer):
 
 Many thanks to Volker, Ryan, Charles and Jeremy for their hard work and support on the Lemmini project over the years. It's such a great program, and the
-fact it's still used many years after its first version makes it worth the extra TLC to keep it up to date
+fact it's still used many years after its first version makes it worth the extra TLC to keep it up to date.
 
-I hope that it can be enjoyed for many years to come
+I hope that it can be enjoyed for many years to come.
 
-### From Charles (RetroLemmini developer):
+### From Charles (SuperLemminiToo developer):
 
 I want to stress that this program was truly written by Volker Oth (Lemmini) and Ryan Sakowski (SuperLemmini), over a combined total of more than twenty years.
 All I've done is hack a couple lines of code. None of this could be possible without the literally thousands of hours of work done by those two individuals,
 and their making the source code freely available. Thanks you both for letting me re-live some joy from my childhood in a new way, and for letting me share
-it with my kids
+it with my kids.
 
 Also special thanks to WillLem from the LemmingsForums.net for providing the updated title graphic, and being all around supportive of this endeavour and
-SuperLemmini in particular
+SuperLemmini in particular.
 
 Special thanks as well to jkapp76 from the LemmingsForums.net for making title icons. I modified them slightly to incorporate them into Icon Labels toggle
-in RetroLemmini
+in SuperLemminiToo.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ A continuation of the Lemmini family of engines (Lemmini, SuperLemmini, RetroLem
 
 To build via the Command Line:
 
-1. Ensure build.xml is present in the source folder
-2. Run: ant
-3. Run: ant LemminiFrame
+1. Install a JDK.
+2. Install Ant, the Java build tool.
+3. Navigate to RetroLemmini's root directory (it contains `build.xml`).
+4. Run `ant` to build.
+5. Run `ant run` to play.
 
 To build via Eclipse IDE:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A continuation of the Lemmini family of engines (Lemmini, SuperLemmini, RetroLemmini) which aims to fix a few bugs and generally update the engine.
 
-# ================= Build Instructions =================
+## Build Instructions
 
-To build via the Command Line:
+### Via the Command Line
 
 1. Install a JDK.
 2. Install Ant, the Java build tool.
@@ -12,40 +12,35 @@ To build via the Command Line:
 4. Run `ant` to build.
 5. Run `ant run` to play.
 
-To build via Eclipse IDE:
+### Via Eclipse IDE
 
 1. Add dependencies to build path
    (Project > Properties > Java Build Path > Libraries > Add Library/Add JARs)
    Navigate to "dependencies" folder and add each one
 2. Run
    RetroLemmini should compile and run without issues, but to get a runnable JAR file it's necessary to Export from Eclipse:
-   
+
    (File > Export > Java > Runnable JAR file > Next)
    Recommended: Copy required libraries into a sub-folder
-   
-If you experience any issues, head to the Lemmini board on the Lemmings Forums:
 
-https://www.lemmingsforums.net/index.php?board=10.0
+If you experience any issues, visit the
+[Lemmini board on Lemmings Forums](https://www.lemmingsforums.net/index.php?board=10.0).
 
-# ================= Updates ============================
+## Updates
 
 For a full overview of the updates between (Super)Lemmini(Too) and RetroLemmini, and the planned updates for the future,
-please visit the Lemmings Forums release topic:
+please visit [RetroLemmini's release topic on Lemmings Forums](https://www.lemmingsforums.net/index.php?msg=105514).
 
-https://www.lemmingsforums.net/index.php?msg=105514
+## Thanks
 
-# =============== THANKS =====================
-
-From Will (RetroLemmini developer):
+### From Will (RetroLemmini developer):
 
 Many thanks to Volker, Ryan, Charles and Jeremy for their hard work and support on the Lemmini project over the years. It's such a great program, and the
 fact it's still used many years after its first version makes it worth the extra TLC to keep it up to date
 
 I hope that it can be enjoyed for many years to come
 
-# =============== THANKS =====================
-
-From Charles (RetroLemmini developer):
+### From Charles (RetroLemmini developer):
 
 I want to stress that this program was truly written by Volker Oth (Lemmini) and Ryan Sakowski (SuperLemmini), over a combined total of more than twenty years.
 All I've done is hack a couple lines of code. None of this could be possible without the literally thousands of hours of work done by those two individuals,

--- a/build.xml
+++ b/build.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- WARNING: Eclipse auto-generated file.
-              Any modifications will be overwritten.
-              To include a user specific buildfile here, simply create one in the same
-              directory with the processing instruction <?eclipse.ant.import?>
-              as the first entry and export the buildfile again. --><project basedir="." default="build" name="RetroLemmini">
+<project basedir="." default="build" name="RetroLemmini">
     <property environment="env"/>
     <property name="debuglevel" value="source,lines,vars"/>
     <property name="target" value="1.8"/>
@@ -78,7 +74,7 @@
         </javac>
     </target>
     <target description="Build all projects which reference this project. Useful to propagate changes." name="build-refprojects"/>
-    <target name="LemminiFrame">
+    <target name="run">
         <java classname="lemmini.LemminiFrame" failonerror="true" fork="yes">
             <classpath refid="run.LemminiFrame.classpath"/>
         </java>


### PR DESCRIPTION
Rename the Ant target from `LemminiFrame` to `run`. The build instructions become now:

* To build: `ant`
* To play: `ant run`

Explain these new build steps in the readme.

Fix attribution in the readme: Charles developed SuperLemminiToo, not RetroLemmini.

Format headers in the readme with `##` and `###`, and remove the loads of `=`. Now the readme renders nicely on RetroLemmini's main page on GitHub.

Format the weblinks to Lemmings Forums in the readme. 